### PR TITLE
Mod2wav command-line rendering

### DIFF
--- a/src/pt2_helpers.c
+++ b/src/pt2_helpers.c
@@ -79,6 +79,9 @@ bool moduleNameIsEmpty(char *name)
 
 void updateWindowTitle(bool modified)
 {
+	if (headless)
+		return;
+
 	char titleTemp[128];
 
 	if (modified)

--- a/src/pt2_mod2wav.c
+++ b/src/pt2_mod2wav.c
@@ -188,24 +188,29 @@ bool renderToWav(char *fileName, bool checkIfFileExist)
 
 	modSetTempo(song->currBPM, true); // update BPM with MOD2WAV audio output rate
 
-	editor.mod2WavThread = SDL_CreateThread(mod2WavThreadFunc, NULL, fOut);
-	if (editor.mod2WavThread != NULL)
+	if (headless)
 	{
-		SDL_DetachThread(editor.mod2WavThread);
+		mod2WavThreadFunc(fOut);
 	}
 	else
 	{
-		free(mod2WavBuffer);
+		editor.mod2WavThread = SDL_CreateThread(mod2WavThreadFunc, NULL, fOut);
+		if (editor.mod2WavThread == NULL)
+		{
+			free(mod2WavBuffer);
 
-		ui.disableVisualizer = false;
-		editor.isWAVRendering = false;
+			ui.disableVisualizer = false;
+			editor.isWAVRendering = false;
 
-		displayErrorMsg("THREAD ERROR");
+			displayErrorMsg("THREAD ERROR");
 
-		pointerSetMode(POINTER_MODE_IDLE, DO_CARRY);
-		statusAllRight();
+			pointerSetMode(POINTER_MODE_IDLE, DO_CARRY);
+			statusAllRight();
 
-		return false;
+			return false;
+		}
+
+		SDL_DetachThread(editor.mod2WavThread);
 	}
 
 	return true;

--- a/src/pt2_structs.c
+++ b/src/pt2_structs.c
@@ -7,3 +7,5 @@ editor_t editor;
 diskop_t diskop;
 cursor_t cursor;
 ui_t ui;
+
+bool headless;

--- a/src/pt2_structs.h
+++ b/src/pt2_structs.h
@@ -268,4 +268,6 @@ extern diskop_t diskop;
 extern cursor_t cursor;
 extern ui_t ui;
 
+extern bool headless;
+
 extern module_t *song; // pt2_main.c

--- a/src/pt2_textout.c
+++ b/src/pt2_textout.c
@@ -709,6 +709,12 @@ void displayMsg(const char *msg)
 {
 	assert(msg != NULL);
 
+	if (headless)
+	{
+		printf("%s\n", msg);
+		return;
+	}
+
 	editor.errorMsgActive = true;
 	editor.errorMsgBlock = false;
 	editor.errorMsgCounter = 0;
@@ -720,6 +726,12 @@ void displayMsg(const char *msg)
 void displayErrorMsg(const char *msg)
 {
 	assert(msg != NULL);
+
+	if (headless)
+	{
+		fprintf(stderr, "[ERROR]: %s\n", msg);
+		return;
+	}
 
 	editor.errorMsgActive = true;
 	editor.errorMsgBlock = true;

--- a/src/pt2_visuals.c
+++ b/src/pt2_visuals.c
@@ -1244,6 +1244,8 @@ void renderEditOpScreen(void)
 
 void renderMOD2WAVDialog(void)
 {
+	if (headless)
+		return;
 	blit32(64, 27, 192, 48, mod2wavBMP);
 }
 


### PR DESCRIPTION
Hello,
I added a command-line option that allows the user to render a MOD file to WAV without going through the GUI.

Usage:
`pt2-clone example.mod --mod2wav`

A WAV file called "example.mod.wav" is then created and rendered using the existing mod2wav code. 
To do this, the program skips SDL initialization and runs the program in a "headless" mode.

I'm using a global bool called "headless" which is set to true when using "--mod2wav" and it is used to skip over SDL code that would otherwise cause a crash if SDL is uninitialized.

I'm sure you are probably going to have objections to the way I implemented some things. If this mod2wav command-line feature is something you'd like to keep, I'd be happy to fix things if you have any suggestions.