### PR TITLE
Fix problem with mouse in fullscreen mode

### DIFF
--- a/src/pt2_config.c
+++ b/src/pt2_config.c
@@ -68,6 +68,7 @@ void loadConfig(void)
 	config.integerScaling = true;
 	config.audioInputFrequency = 44100;
 	config.keepEditModeAfterStepPlay = false;
+	config.resizable = false;
 
 	config.maxSampleLength = 65534;
 	config.reservedSampleOffset = (MOD_SAMPLES+1) * config.maxSampleLength;
@@ -471,6 +472,12 @@ static bool loadProTrackerDotIni(FILE *f)
 			}
 		}
 
+		// WINDOW RESIZABLE
+		else if (!_strnicmp(configLine, "RESIZABLE=", 10))
+		{
+			if (!_strnicmp(&configLine[10], "TRUE",  4)) config.resizable = true;
+			else if (!_strnicmp(&configLine[10], "FALSE", 5)) config.resizable = false;
+		}
 		configLine = strtok(NULL, "\n");
 	}
 

--- a/src/pt2_config.h
+++ b/src/pt2_config.h
@@ -16,6 +16,7 @@ typedef struct config_t
 	bool waveformCenterLine, pattDots, compoMode, autoCloseDiskOp, hideDiskOpDates, hwMouse;
 	bool transDel, fullScreenStretch, vsyncOff, modDot, blankZeroFlag, realVuMeters, rememberPlayMode;
 	bool startInFullscreen, integerScaling, disableE8xEffect, noDownsampleOnSmpLoad, keepEditModeAfterStepPlay;
+	bool resizable;
 	int8_t stereoSeparation, videoScaleFactor, accidental;
 	uint8_t pixelFilter, filterModel;
 	uint16_t quantizeValue;

--- a/src/pt2_main.c
+++ b/src/pt2_main.c
@@ -372,6 +372,9 @@ static void handleInput(void)
 			else if (event.window.event == SDL_WINDOWEVENT_SHOWN)
 				video.windowHidden = false;
 
+			updateRenderSizeVars();
+			updateMouseScaling();
+
 			// reset vblank end time if we minimize window
 			if (event.window.event == SDL_WINDOWEVENT_MINIMIZED || event.window.event == SDL_WINDOWEVENT_FOCUS_LOST)
 				hpc_ResetEndTime(&video.vblankHpc);

--- a/src/pt2_mouse.c
+++ b/src/pt2_mouse.c
@@ -283,47 +283,40 @@ void readMouseXY(void)
 	mouse.rawX = mx;
 	mouse.rawY = my;
 
-	if (video.fullscreen)
+	// if software mouse is enabled, warp mouse inside render space
+	if (!config.hwMouse)
 	{
-		// centered fullscreen mode (not stretched) needs further coord translation
-		if (!config.fullScreenStretch)
+		bool warpMouse = false;
+
+		if (mx < video.renderX)
 		{
-			// if software mouse is enabled, warp mouse inside render space
-			if (!config.hwMouse)
-			{
-				bool warpMouse = false;
-
-				if (mx < video.renderX)
-				{
-					mx = video.renderX;
-					warpMouse = true;
-				}
-				else if (mx >= video.renderX+video.renderW)
-				{
-					mx = (video.renderX + video.renderW) - 1;
-					warpMouse = true;
-				}
-
-				if (my < video.renderY)
-				{
-					my = video.renderY;
-					warpMouse = true;
-				}
-				else if (my >= video.renderY+video.renderH)
-				{
-					my = (video.renderY + video.renderH) - 1;
-					warpMouse = true;
-				}
-
-				if (warpMouse)
-					SDL_WarpMouseInWindow(video.window, mx, my);
-			}
-
-			// convert fullscreen coords to window (centered image) coords
-			mx -= video.renderX;
-			my -= video.renderY;
+			mx = video.renderX;
+			warpMouse = true;
 		}
+		else if (mx >= video.renderX+video.renderW)
+		{
+			mx = (video.renderX + video.renderW) - 1;
+			warpMouse = true;
+		}
+
+		if (my < video.renderY)
+		{
+			my = video.renderY;
+			warpMouse = true;
+		}
+		else if (my >= video.renderY+video.renderH)
+		{
+			my = (video.renderY + video.renderH) - 1;
+			warpMouse = true;
+		}
+
+		if (warpMouse)
+			SDL_WarpMouseInWindow(video.window, mx, my);
 	}
+
+	// convert fullscreen coords to window (centered image) coords
+	mx -= video.renderX;
+	my -= video.renderY;
 
 	// multiply coords by video upscaling factors (don't round)
 	mouse.x = (int32_t)(mx * video.fMouseXMul);
@@ -2355,7 +2348,7 @@ bool handleLeftMouseButton(void)
 	}
 
 	// if in fullscreen mode and the image isn't filling the whole screen, handle top left corner as quit
-	if (video.fullscreen && (video.renderX > 0 || video.renderY > 0) && (mouse.rawX == 0 && mouse.rawY == 0))
+	if ((video.renderX > 0 || video.renderY > 0) && (mouse.rawX == 0 && mouse.rawY == 0))
 		return handleGUIButtons(PTB_QUIT);
 
 	guiButton = checkGUIButtons();

--- a/src/pt2_visuals.c
+++ b/src/pt2_visuals.c
@@ -2271,6 +2271,8 @@ void toggleFullScreen(void)
 	video.fullscreen ^= 1;
 	if (video.fullscreen)
 	{
+		SDL_SetWindowFullscreen(video.window, SDL_WINDOW_FULLSCREEN_DESKTOP);
+
 		if (config.fullScreenStretch)
 		{
 			SDL_GetDesktopDisplayMode(0, &dm);
@@ -2282,7 +2284,6 @@ void toggleFullScreen(void)
 		}
 
 		SDL_SetWindowSize(video.window, SCREEN_W, SCREEN_H);
-		SDL_SetWindowFullscreen(video.window, SDL_WINDOW_FULLSCREEN_DESKTOP);
 		SDL_SetWindowGrab(video.window, SDL_TRUE);
 	}
 	else

--- a/src/pt2_visuals.h
+++ b/src/pt2_visuals.h
@@ -47,6 +47,7 @@ void sinkVisualizerBars(void);
 void updatePosEd(void);
 void updateVisualizer(void);
 void updateEditOp(void);
+void updateRenderSizeVars(void);
 void toggleFullScreen(void);
 void videoClose(void);
 


### PR DESCRIPTION
This simple patch should fix problem with fullscreen in Linux (issue #11 ) and probably in other systems. The problem was due to reading desktop size before switching to fullscreen and apparently setting windows size before fullscreen mode.  Now it works at least for me without issues.