### PR TITLE
Allow SDL's automatic audio output format conversion

### DIFF
--- a/src/pt2_audio.c
+++ b/src/pt2_audio.c
@@ -430,7 +430,7 @@ bool setupAudio(void)
 	want.callback = audioCallback;
 	want.userdata = NULL;
 
-	dev = SDL_OpenAudioDevice(NULL, 0, &want, &have, SDL_AUDIO_ALLOW_ANY_CHANGE);
+	dev = SDL_OpenAudioDevice(NULL, 0, &want, &have, SDL_AUDIO_ALLOW_FREQUENCY_CHANGE);
 	if (dev == 0)
 	{
 		showErrorMsgBox("Couldn't open audio device:\n\"%s\"\n\nDo you have an audio device enabled and plugged in?", SDL_GetError());
@@ -442,12 +442,6 @@ bool setupAudio(void)
 	if (have.freq < minFreq)
 	{
 		showErrorMsgBox("Unable to open audio: An audio rate below %dHz can't be used!", minFreq);
-		return false;
-	}
-
-	if (have.format != AUDIO_S16)
-	{
-		showErrorMsgBox("Couldn't open audio device:\nThis program only supports 16-bit audio streams. Sorry!");
 		return false;
 	}
 


### PR DESCRIPTION
pt2-clone still handles variations in output frequency itself, but SDL will now convert the output for devices that don't support S16 format or have a different number of channels.

I ran into this using SDL's JACK output device on Linux, but I've also had a soundcard in the past that only supported 24-bit output in hardware, so this should deal with that kind of problem too. The recording code in pt2_sampling.c already allows conversion so no changes are needed there (and it works fine with JACK).